### PR TITLE
Curios compat

### DIFF
--- a/src/main/resources/data/forge/tags/items/charm.json
+++ b/src/main/resources/data/forge/tags/items/charm.json
@@ -1,0 +1,10 @@
+{
+  "replace": false,
+  "values": [
+    "fins:gem_crab_amulet"
+    "fins:spindly_pearl_charm"
+    "fins:spindly_ruby_charm"
+    "fins:spindly_amber_charm"
+    "fins:spindly_sapphire_charm"
+    "fins:spindly_emerald_charm"]
+}


### PR DESCRIPTION
Adds cross-mod compatibility between Fins and Curios by allowing Spindly Gem Charms to be optionally equipped in the Curios charm slot